### PR TITLE
Use better(ish) palettes for areas with palette swaps

### DIFF
--- a/patch_GomezHost.cs
+++ b/patch_GomezHost.cs
@@ -25,14 +25,24 @@ namespace FezGame.Components
 
             GomezEffect effect = this.GetType().GetField("effect", f).GetValue(this) as GomezEffect;
 
-            //Logger.Log("Test", (effect != null) ? "true" : "false");
-
             if (effect == null) return;
 
-            if (effect.ColorSwapMode != ColorSwapMode.Cmyk) return;
-
             SemanticMappedVector3 blackSwap = effect.GetType().GetField("blackSwap", f).GetValue(effect) as SemanticMappedVector3;
-            blackSwap.Set(new Vector3(0f, 0f, 1.0f));
+
+            switch (effect.ColorSwapMode)
+            {
+                case ColorSwapMode.VirtualBoy:
+                    blackSwap.Set(new Vector3(101f / 255f, 1f / 255f, 0f));
+                    break;
+                case ColorSwapMode.Gameboy:
+                    blackSwap.Set(new Vector3(82f / 255f, 127f / 255f, 19f / 85f));
+                    break;
+                case ColorSwapMode.Cmyk:
+                    blackSwap.Set(new Vector3(0f, 92f / 255f, 127f / 255f));
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
Now that GDQ is over and this Sonez skin might never get used again since it's illegal in speedruns, it's the perfect time for me to make a pull request :D Jokes aside, this will be useful if someone submits a longer category (e.g. full completion) to a marathon with this skin as a donation incentive.

This improves the palettes in the three sub areas where Gomez gets a palette swap. The CMYK area is a darkened cyan which I think is slightly improved over just pure blue, but it's the one I'm still the most shaky on. The other two were directly copied from what the grey color in the palette swap is.

Some pikshures:

| | Before | After |
| --- | --- | --- |
| VirtualBoy | ![SonezBeforeVirtualBoy](https://user-images.githubusercontent.com/7307599/212607920-92f9526f-5be2-4cf9-8370-faebc1c63aa0.png) | ![SonezBetterishVirtualBoy](https://user-images.githubusercontent.com/7307599/212607918-f507b524-6313-4ed3-a3e9-80cc7fd23b2a.png) |
| Gameboy | ![SonezBeforeGameboy](https://user-images.githubusercontent.com/7307599/212607988-a9fdf189-2ff2-460f-b2a1-eecc821067f5.png) | ![SonezBetterishGameboy](https://user-images.githubusercontent.com/7307599/212608015-f042455e-0363-4c2c-ba05-524b0d7bfa45.png) |
| CMYK | (Totally vanilla) ![SonezBeforeCMYK1](https://user-images.githubusercontent.com/7307599/212608050-2322341e-4a67-44e4-b16e-bfa29b19f1dc.png) (Pure blue) ![SonezBeforeCMYK2](https://user-images.githubusercontent.com/7307599/212608082-1d46a70d-7417-421b-949a-5f2a4d6512a4.png) | ![SonezBetterishCMYK](https://user-images.githubusercontent.com/7307599/212608107-9313607f-49d5-44ce-9962-60698518f9a8.png) |